### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,9 @@ nx=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 4)
 xpid=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 8)
 [ -n "${ver}" ] && wget -O $nx.zip https://github.com/XTLS/Xray-core/releases/download/v${ver}/Xray-linux-64.zip
 [ ! -s $nx.zip ] && wget -O $nx.zip https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-64.zip
-unzip $nx.zip && rm -f $nx.zip
+unzip $nx.zip xray && rm -f $nx.zip
+wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
+wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
 chmod a+x xray && mv xray $xpid
 sed -i "s/uuid/$uuid/g" ./config.json
 sed -i "s/uuid/$uuid/g" /etc/nginx/nginx.conf


### PR DESCRIPTION
我看了整個部署過程的命令，如果要保留`geosite.dat`與`geoip.dat`作為未來分流的用途，建議採用新版，修改後的代碼會在每次部署時自動下載最新的資料庫。
如果因為考量`geosite.dat`與`geoip.dat`的名稱會成為腳本特徵而決定犧牲掉未來分流的擴展性的話，可以僅保留第7行即可，這樣只會解壓出xray核心。而不會解壓出壓縮包內置的`geosite.dat`與`geoip.dat`。